### PR TITLE
Bug fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.3</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
resolved: net.alchim31.maven:scala-maven-plugin:3.2.0:compile (default) on project spark-mongo-example: Execution default of goal net.alchim31.maven:scala-maven-plugin:3.2.0:compile failed.: CompileFailed